### PR TITLE
Improve student activity registration system

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 httpx
 watchfiles
+pytest

--- a/src/README.md
+++ b/src/README.md
@@ -25,6 +25,20 @@ A super simple FastAPI application that allows students to view and sign up for 
    - API documentation: http://localhost:8000/docs
    - Alternative documentation: http://localhost:8000/redoc
 
+## Running Tests
+
+1. Install dependencies from the repository root:
+
+   ```
+   pip install -r requirements.txt
+   ```
+
+2. Run backend tests from the repository root:
+
+   ```
+   pytest -q
+   ```
+
 ## API Endpoints
 
 | Method | Endpoint                                                          | Description                                                         |

--- a/src/app.py
+++ b/src/app.py
@@ -107,3 +107,18 @@ def signup_for_activity(activity_name: str, email: str):
         raise HTTPException(status_code=400, detail="Student already signed up for this activity")
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}
+
+
+@app.delete("/activities/{activity_name}/participants")
+def unregister_participant(activity_name: str, email: str):
+    """Remove a student from an activity"""
+    if activity_name not in activities:
+        raise HTTPException(status_code=404, detail="Activity not found")
+
+    activity = activities[activity_name]
+
+    if email not in activity["participants"]:
+        raise HTTPException(status_code=404, detail="Participant not found in this activity")
+
+    activity["participants"].remove(email)
+    return {"message": f"Removed {email} from {activity_name}"}

--- a/src/app.py
+++ b/src/app.py
@@ -21,25 +21,64 @@ app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
 
 # In-memory activity database
 activities = {
-    "Chess Club": {
-        "description": "Learn strategies and compete in chess tournaments",
-        "schedule": "Fridays, 3:30 PM - 5:00 PM",
-        "max_participants": 12,
-        "participants": ["michael@mergington.edu", "daniel@mergington.edu"]
-    },
-    "Programming Class": {
-        "description": "Learn programming fundamentals and build software projects",
-        "schedule": "Tuesdays and Thursdays, 3:30 PM - 4:30 PM",
-        "max_participants": 20,
-        "participants": ["emma@mergington.edu", "sophia@mergington.edu"]
-    },
-    "Gym Class": {
-        "description": "Physical education and sports activities",
-        "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
-        "max_participants": 30,
-        "participants": ["john@mergington.edu", "olivia@mergington.edu"]
+        "Chess Club": {
+            "description": "Learn strategies and compete in chess tournaments",
+            "schedule": "Fridays, 3:30 PM - 5:00 PM",
+            "max_participants": 12,
+            "participants": ["michael@mergington.edu", "daniel@mergington.edu"]
+        },
+        "Programming Class": {
+            "description": "Learn programming fundamentals and build software projects",
+            "schedule": "Tuesdays and Thursdays, 3:30 PM - 4:30 PM",
+            "max_participants": 20,
+            "participants": ["emma@mergington.edu", "sophia@mergington.edu"]
+        },
+        "Gym Class": {
+            "description": "Physical education and sports activities",
+            "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
+            "max_participants": 30,
+            "participants": ["john@mergington.edu", "olivia@mergington.edu"]
+        },
+        # Sports related activities
+        "Soccer Team": {
+            "description": "Join the school soccer team and compete in local leagues",
+            "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
+            "max_participants": 18,
+            "participants": ["lucas@mergington.edu", "mia@mergington.edu"]
+        },
+        "Basketball Club": {
+            "description": "Practice basketball skills and play friendly matches",
+            "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+            "max_participants": 15,
+            "participants": ["liam@mergington.edu", "ava@mergington.edu"]
+        },
+        # Artistic activities
+        "Art Club": {
+            "description": "Explore painting, drawing, and other visual arts",
+            "schedule": "Mondays, 3:30 PM - 5:00 PM",
+            "max_participants": 16,
+            "participants": ["ella@mergington.edu", "noah@mergington.edu"]
+        },
+        "Drama Society": {
+            "description": "Participate in theater productions and acting workshops",
+            "schedule": "Thursdays, 4:00 PM - 5:30 PM",
+            "max_participants": 20,
+            "participants": ["amelia@mergington.edu", "jack@mergington.edu"]
+        },
+        # Intellectual activities
+        "Math Olympiad": {
+            "description": "Prepare for math competitions and solve challenging problems",
+            "schedule": "Fridays, 2:00 PM - 3:30 PM",
+            "max_participants": 10,
+            "participants": ["charlotte@mergington.edu", "benjamin@mergington.edu"]
+        },
+        "Science Club": {
+            "description": "Conduct experiments and explore scientific concepts",
+            "schedule": "Wednesdays, 4:00 PM - 5:00 PM",
+            "max_participants": 14,
+            "participants": ["henry@mergington.edu", "grace@mergington.edu"]
+        }
     }
-}
 
 
 @app.get("/")
@@ -63,5 +102,8 @@ def signup_for_activity(activity_name: str, email: str):
     activity = activities[activity_name]
 
     # Add student
+    # Validate student is not already signed up
+    if email in activity["participants"]:
+        raise HTTPException(status_code=400, detail="Student already signed up for this activity")
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -7,11 +7,12 @@ document.addEventListener("DOMContentLoaded", () => {
   // Function to fetch activities from API
   async function fetchActivities() {
     try {
-      const response = await fetch("/activities");
+      const response = await fetch("/activities", { cache: "no-store" });
       const activities = await response.json();
 
       // Clear loading message
       activitiesList.innerHTML = "";
+      activitySelect.innerHTML = '<option value="">-- Select an activity --</option>';
 
       // Populate activities list
       Object.entries(activities).forEach(([name, details]) => {
@@ -19,12 +20,40 @@ document.addEventListener("DOMContentLoaded", () => {
         activityCard.className = "activity-card";
 
         const spotsLeft = details.max_participants - details.participants.length;
+        const encodedActivityName = encodeURIComponent(name);
+        const participantsList = details.participants.length
+          ? details.participants
+              .map(
+                (participant) => `
+                <li class="participant-item">
+                  <span class="participant-email">${participant}</span>
+                  <button
+                    type="button"
+                    class="delete-participant-btn"
+                    data-activity="${encodedActivityName}"
+                    data-email="${encodeURIComponent(participant)}"
+                    title="Unregister ${participant}"
+                    aria-label="Unregister ${participant}"
+                  >
+                    &#128465;
+                  </button>
+                </li>
+              `
+              )
+              .join("")
+          : '<li class="empty-state">No participants yet</li>';
 
         activityCard.innerHTML = `
           <h4>${name}</h4>
           <p>${details.description}</p>
           <p><strong>Schedule:</strong> ${details.schedule}</p>
           <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
+          <div class="participants-section">
+            <p class="participants-title">Participants</p>
+            <ul class="participants-list">
+              ${participantsList}
+            </ul>
+          </div>
         `;
 
         activitiesList.appendChild(activityCard);
@@ -62,6 +91,7 @@ document.addEventListener("DOMContentLoaded", () => {
         messageDiv.textContent = result.message;
         messageDiv.className = "success";
         signupForm.reset();
+        await fetchActivities();
       } else {
         messageDiv.textContent = result.detail || "An error occurred";
         messageDiv.className = "error";
@@ -78,6 +108,50 @@ document.addEventListener("DOMContentLoaded", () => {
       messageDiv.className = "error";
       messageDiv.classList.remove("hidden");
       console.error("Error signing up:", error);
+    }
+  });
+
+  activitiesList.addEventListener("click", async (event) => {
+    const deleteButton = event.target.closest(".delete-participant-btn");
+    if (!deleteButton) {
+      return;
+    }
+
+    const activity = decodeURIComponent(deleteButton.dataset.activity || "");
+    const email = decodeURIComponent(deleteButton.dataset.email || "");
+
+    if (!activity || !email) {
+      return;
+    }
+
+    try {
+      const response = await fetch(
+        `/activities/${encodeURIComponent(activity)}/participants?email=${encodeURIComponent(email)}`,
+        {
+          method: "DELETE",
+        }
+      );
+
+      const result = await response.json();
+
+      if (response.ok) {
+        messageDiv.textContent = result.message;
+        messageDiv.className = "success";
+        await fetchActivities();
+      } else {
+        messageDiv.textContent = result.detail || "Failed to remove participant";
+        messageDiv.className = "error";
+      }
+
+      messageDiv.classList.remove("hidden");
+      setTimeout(() => {
+        messageDiv.classList.add("hidden");
+      }, 5000);
+    } catch (error) {
+      messageDiv.textContent = "Failed to remove participant. Please try again.";
+      messageDiv.className = "error";
+      messageDiv.classList.remove("hidden");
+      console.error("Error removing participant:", error);
     }
   });
 

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -74,6 +74,82 @@ section h3 {
   margin-bottom: 8px;
 }
 
+.participants-section {
+  margin-top: 12px;
+  padding: 12px;
+  border: 1px solid #d6e4ff;
+  border-radius: 8px;
+  background: linear-gradient(180deg, #f7faff 0%, #eef4ff 100%);
+}
+
+.participants-title {
+  margin-bottom: 8px;
+  font-weight: 700;
+  color: #1a237e;
+  letter-spacing: 0.2px;
+}
+
+.participants-list {
+  margin: 0;
+  padding-left: 0;
+  list-style: none;
+}
+
+.participants-list li {
+  margin-bottom: 8px;
+  color: #1f2d3d;
+}
+
+.participants-list li:last-child {
+  margin-bottom: 0;
+}
+
+.participants-list .empty-state {
+  font-style: italic;
+  color: #6c757d;
+}
+
+.participant-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 8px 10px;
+  border-radius: 6px;
+  background-color: #ffffff;
+  border: 1px solid #dbe8ff;
+}
+
+.participant-email {
+  font-size: 0.95rem;
+  word-break: break-word;
+}
+
+.delete-participant-btn {
+  width: 30px;
+  height: 30px;
+  border: 1px solid #ef9a9a;
+  border-radius: 6px;
+  background-color: #ffebee;
+  color: #c62828;
+  font-size: 16px;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background-color 0.2s, transform 0.2s;
+}
+
+.delete-participant-btn:hover {
+  background-color: #ffcdd2;
+  transform: translateY(-1px);
+}
+
+.delete-participant-btn:active {
+  transform: translateY(0);
+}
+
 .form-group {
   margin-bottom: 15px;
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,22 @@
+import copy
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.app import activities, app
+
+
+@pytest.fixture
+def client():
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+@pytest.fixture(autouse=True)
+def reset_activities_state():
+    original_activities = copy.deepcopy(activities)
+    activities.clear()
+    activities.update(copy.deepcopy(original_activities))
+    yield
+    activities.clear()
+    activities.update(original_activities)

--- a/tests/test_activities_api.py
+++ b/tests/test_activities_api.py
@@ -1,0 +1,97 @@
+from urllib.parse import quote
+
+from src.app import activities
+
+
+def test_root_redirects_to_static_page(client):
+    response = client.get("/", follow_redirects=False)
+
+    assert response.status_code == 307
+    assert response.headers["location"] == "/static/index.html"
+
+
+def test_get_activities_returns_expected_structure(client):
+    response = client.get("/activities")
+
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert isinstance(payload, dict)
+    assert "Chess Club" in payload
+    assert "description" in payload["Chess Club"]
+    assert "schedule" in payload["Chess Club"]
+    assert "max_participants" in payload["Chess Club"]
+    assert "participants" in payload["Chess Club"]
+
+
+def test_signup_adds_new_participant(client):
+    activity_name = "Chess Club"
+    email = "new.student@mergington.edu"
+
+    response = client.post(
+        f"/activities/{quote(activity_name, safe='')}/signup",
+        params={"email": email},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["message"] == f"Signed up {email} for {activity_name}"
+    assert email in activities[activity_name]["participants"]
+
+
+def test_signup_rejects_duplicate_participant(client):
+    activity_name = "Chess Club"
+    existing_email = "michael@mergington.edu"
+
+    response = client.post(
+        f"/activities/{quote(activity_name, safe='')}/signup",
+        params={"email": existing_email},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Student already signed up for this activity"
+
+
+def test_signup_returns_404_for_missing_activity(client):
+    response = client.post(
+        f"/activities/{quote('Unknown Activity', safe='')}/signup",
+        params={"email": "test@mergington.edu"},
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Activity not found"
+
+
+def test_unregister_removes_existing_participant(client):
+    activity_name = "Programming Class"
+    email = "emma@mergington.edu"
+
+    response = client.delete(
+        f"/activities/{quote(activity_name, safe='')}/participants",
+        params={"email": email},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["message"] == f"Removed {email} from {activity_name}"
+    assert email not in activities[activity_name]["participants"]
+
+
+def test_unregister_returns_404_for_missing_activity(client):
+    response = client.delete(
+        f"/activities/{quote('Unknown Activity', safe='')}/participants",
+        params={"email": "student@mergington.edu"},
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Activity not found"
+
+
+def test_unregister_returns_404_for_missing_participant(client):
+    activity_name = "Gym Class"
+
+    response = client.delete(
+        f"/activities/{quote(activity_name, safe='')}/participants",
+        params={"email": "not.in.list@mergington.edu"},
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Participant not found in this activity"


### PR DESCRIPTION
This pull request introduces participant management features to the student activities application, including the ability to unregister participants, display participant lists in the UI, and comprehensive backend and frontend support for these features. It also adds automated tests and documentation for running them.

**Backend enhancements:**

* Added a new endpoint to allow unregistering (removing) a participant from an activity, with proper error handling for missing activities or participants. Also added validation to prevent duplicate signups. (`src/app.py`)
* Expanded the in-memory `activities` data to include more diverse sample activities (sports, arts, intellectual clubs). (`src/app.py`)

**Frontend improvements:**

* Updated the UI to display a list of participants for each activity, including a button to remove (unregister) a participant. The UI refreshes automatically after participant changes. (`src/static/app.js`, `src/static/styles.css`) [[1]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3L10-R56) [[2]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R114-R157) [[3]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R94) [[4]](diffhunk://#diff-090bb81494e72cfcac6b0a6065f88e9caf9d80c00b887e38f02a690dbec0f8b2R77-R152)

**Testing and documentation:**

* Added a test suite for the activities API, covering signup, duplicate prevention, unregistering, and error cases. (`tests/test_activities_api.py`)
* Introduced fixtures to reset application state between tests for isolation. (`tests/conftest.py`)
* Documented how to run backend tests in the project README. (`src/README.md`)